### PR TITLE
make compatible with bundler >= 1.0 and allow for rspec >=2

### DIFF
--- a/Support/lib/cucumber/mate.rb
+++ b/Support/lib/cucumber/mate.rb
@@ -7,7 +7,7 @@ if ENV['TM_PROJECT_DIRECTORY']
   bundler_gemfile = File.join(ENV['TM_PROJECT_DIRECTORY'], 'Gemfile')
   if File.exists?(bundler_gemfile)
     bundle_path = (File.read(bundler_gemfile) =~ (/bundle_path[ (]+['"](.*?)['"]/) && $1) || ".bundle"
-    require File.join(ENV['TM_PROJECT_DIRECTORY'], bundle_path, "environment")
+    require 'bundler/setup'
   elsif File.directory?(rspec_rails_plugin)
     $LOAD_PATH.unshift(rspec_rails_plugin)
   elsif File.directory?(rspec_merb_gem)
@@ -20,7 +20,11 @@ if ENV['TM_PROJECT_DIRECTORY']
     $LOAD_PATH.unshift(rspec_lib)
   end
 end
-require 'spec'
+begin
+  require 'rspec'
+rescue LoadError
+  require 'spec'
+end
 
 $LOAD_PATH.unshift(File.expand_path(File.join(File.dirname(__FILE__), '..')))
 require "cucumber/mate/feature_helper"


### PR DESCRIPTION
I see that there are lots of pull requests open for these issues, so I'll go ahead and pile mine on. 
- rspec 2 is preferred, but it will fall back to rspec 1
- the .bundle/environment behavior is deprecated. I didn't actually provide a fallback to this behavior, but perhaps that would be nice. I tend to think not.

It's important to fix this because cuking is just not the same from the command line.
