### PR TITLE
Updated the Installation Instructions to reflect new Cucumber org

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -38,7 +38,7 @@ h2. Installation
 <pre>
 mkdir -p ~/Library/Application\ Support/TextMate/Bundles/
 cd ~/Library/Application\ Support/TextMate/Bundles
-git clone git://github.com/aslakhellesoy/cucumber-tmbundle.git Cucumber.tmbundle
+git clone git://github.com/cucumber/cucumber-tmbundle.git Cucumber.tmbundle
 osascript -e 'tell app "TextMate" to reload bundles'
 </pre>
 


### PR DESCRIPTION
Hi,

I updated the Installation Instructions to reflect new Cucumber GitHub organization.

The github repo path has moved from:
git://github.com/aslakhellesoy/cucumber-tmbundle.git

to
git://github.com/cucumber/cucumber-tmbundle.git

Cheers,
John
