### PR TITLE
Removed old include of #description from the plain text feature syntax

### DIFF
--- a/Syntaxes/Cucumber Plain Text Feature.tmLanguage
+++ b/Syntaxes/Cucumber Plain Text Feature.tmLanguage
@@ -24,10 +24,6 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#description</string>
-		</dict>
-		<dict>
-			<key>include</key>
 			<string>#feature_keyword</string>
 		</dict>
 		<dict>

--- a/Syntaxes/plaintext_template.erb
+++ b/Syntaxes/plaintext_template.erb
@@ -24,10 +24,6 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#description</string>
-		</dict>
-		<dict>
-			<key>include</key>
 			<string>#feature_keyword</string>
 		</dict>
 		<dict>


### PR DESCRIPTION
I removed the old include of #description from the plain text feature syntax so that it works with Sublime Text, which is fussier about such things.
