### PR TITLE
Don’t overwrite TM_SUPPORT_PATH

### DIFF
--- a/support/spec/spec_helper.rb
+++ b/support/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'rspec/core'
 
-ENV['TM_SUPPORT_PATH'] = '/Applications/TextMate.app/Contents/SharedSupport/Support'
+ENV['TM_SUPPORT_PATH'] = '/Applications/TextMate.app/Contents/SharedSupport/Support' unless ENV.has_key?('TM_SUPPORT_PATH')
 
 RSpec.configure do |c|
   c.include(Module.new do


### PR DESCRIPTION
The hardcoded path won’t work for 2.0 or for users who didn’t install TextMate in /Applications (or possibly renamed it), so only use it as a fallback.
